### PR TITLE
featurize json, yaml, bincode and cbor serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,20 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "seladb/pickledb-rs" }
 
+[features]
+default = ["json"]
+json = ["serde_json"]
+yaml = ["serde_yaml"]
+cbor = ["serde_cbor"]
+
 [dependencies]
 serde = "1.0.82"
-serde_json = "1.0"
+serde_json = { version = "1.0", optional = true }
 serde_derive = "1.0"
-bincode = "1.0.1"
-serde_yaml = "0.8.8"
-serde_cbor = "0.9.0"
+bincode = { version = "1.0.1", optional = true }
+serde_yaml = { version = "0.8.8", optional = true }
+serde_cbor = { version = "0.9.0", optional = true }
+
 
 [dev-dependencies]
 rand = "0.6.3"

--- a/src/pickledb.rs
+++ b/src/pickledb.rs
@@ -68,6 +68,7 @@ impl PickleDb {
             last_dump: Instant::now() }
     }
 
+    #[cfg(feature = "json")]
     /// Constructs a new `PickleDB` instance that uses [JSON serialization](https://crates.io/crates/serde_json) for storing the data.
     /// 
     /// # Arguments
@@ -88,6 +89,7 @@ impl PickleDb {
         PickleDb::new(db_path, dump_policy, SerializationMethod::Json)
     }
 
+    #[cfg(feature = "bincode")]
     /// Constructs a new `PickleDB` instance that uses [Bincode serialization](https://crates.io/crates/bincode) for storing the data.
     /// 
     /// # Arguments
@@ -108,6 +110,7 @@ impl PickleDb {
         PickleDb::new(db_path, dump_policy, SerializationMethod::Bin)
     }
 
+    #[cfg(feature = "yaml")]
     /// Constructs a new `PickleDB` instance that uses [YAML serialization](https://crates.io/crates/serde_yaml) for storing the data.
     /// 
     /// # Arguments
@@ -128,6 +131,7 @@ impl PickleDb {
         PickleDb::new(db_path, dump_policy, SerializationMethod::Yaml)
     }
 
+    #[cfg(feature = "cbor")]
     /// Constructs a new `PickleDB` instance that uses [CBOR serialization](https://crates.io/crates/serde_cbor) for storing the data.
     /// 
     /// # Arguments
@@ -206,6 +210,7 @@ impl PickleDb {
             })
     }
 
+    #[cfg(feature = "json")]
     /// Load a DB from a file stored in a Json format
     /// 
     /// This method tries to load a DB from a file serialized in Json format. Upon success an instance of `PickleDB` is returned, 
@@ -229,6 +234,7 @@ impl PickleDb {
         PickleDb::load(db_path, dump_policy, SerializationMethod::Json)
     }
 
+    #[cfg(feature = "bincode")]
     /// Load a DB from a file stored in Bincode format
     /// 
     /// This method tries to load a DB from a file serialized in Bincode format. Upon success an instance of `PickleDB` is returned, 
@@ -252,6 +258,7 @@ impl PickleDb {
         PickleDb::load(db_path, dump_policy, SerializationMethod::Bin)
     }
 
+    #[cfg(feature = "yaml")]
     /// Load a DB from a file stored in Yaml format
     /// 
     /// This method tries to load a DB from a file serialized in Yaml format. Upon success an instance of `PickleDB` is returned, 
@@ -275,6 +282,7 @@ impl PickleDb {
         PickleDb::load(db_path, dump_policy, SerializationMethod::Yaml)
     }
 
+    #[cfg(feature = "cbor")]
     /// Load a DB from a file stored in Cbor format
     /// 
     /// This method tries to load a DB from a file serialized in Cbor format. Upon success an instance of `PickleDB` is returned, 

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,38 +1,31 @@
 use std::collections::HashMap;
 use std::fmt;
 use serde::{de::DeserializeOwned, Serialize};
+#[cfg(feature = "json")]
 use serde_json;
+#[cfg(feature = "bincode")]
 use bincode;
+#[cfg(feature = "yaml")]
 use serde_yaml;
+#[cfg(feature = "cbor")]
 use serde_cbor;
 
 /// An enum for specifying the serialization method to use when creating a new PickleDB database
 /// or loading one from a file 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum SerializationMethod {
+    #[cfg(feature = "json")]
     /// [JSON serialization](https://crates.io/crates/serde_json)
     Json,
-
+    #[cfg(feature = "bincode")]
     /// [Bincode serialization](https://crates.io/crates/bincode)
     Bin,
-
+    #[cfg(feature = "yaml")]
     /// [YAML serialization](https://crates.io/crates/serde_yaml)
     Yaml,
-
+    #[cfg(feature = "cbor")]
     /// [CBOR serialization](https://crates.io/crates/serde_cbor)
     Cbor
-}
-
-impl From<i32> for SerializationMethod {
-    fn from(item: i32) -> Self {
-        match item {
-            0 => SerializationMethod::Json,
-            1 => SerializationMethod::Bin,
-            2 => SerializationMethod::Yaml,
-            3 => SerializationMethod::Cbor,
-            _ => SerializationMethod::Json
-        }
-    }
 }
 
 impl fmt::Display for SerializationMethod {
@@ -42,8 +35,10 @@ impl fmt::Display for SerializationMethod {
 }
 
 
+#[cfg(feature = "json")]
 struct JsonSerializer { }
 
+#[cfg(feature = "json")]
 impl JsonSerializer {
     fn new() -> JsonSerializer {
         JsonSerializer {}
@@ -110,9 +105,12 @@ impl JsonSerializer {
 }
 
 
+#[cfg(feature = "yaml")]
 struct YamlSerializer { }
 
+#[cfg(feature = "yaml")]
 impl YamlSerializer {
+
     fn new() -> YamlSerializer {
         YamlSerializer {}
     }
@@ -178,8 +176,10 @@ impl YamlSerializer {
 }
 
 
+#[cfg(feature = "bincode")]
 struct BincodeSerializer { }
 
+#[cfg(feature = "bincode")]
 impl BincodeSerializer {
     fn new() -> BincodeSerializer {
         BincodeSerializer {}
@@ -218,8 +218,10 @@ impl BincodeSerializer {
 }
 
 
+#[cfg(feature = "cbor")]
 struct CborSerializer { }
 
+#[cfg(feature = "cbor")]
 impl CborSerializer {
     fn new() -> CborSerializer {
         CborSerializer {}
@@ -260,9 +262,13 @@ impl CborSerializer {
 
 pub(crate) struct Serializer {
     ser_method: SerializationMethod,
+    #[cfg(feature = "json")]
     json_serializer: JsonSerializer,
+    #[cfg(feature = "bincode")]
     bincode_serializer: BincodeSerializer,
+    #[cfg(feature = "yaml")]
     yaml_serializer: YamlSerializer,
+    #[cfg(feature = "cbor")]
     cbor_serializer: CborSerializer
 }
 
@@ -271,9 +277,13 @@ impl Serializer {
     pub(crate) fn new(ser_method: SerializationMethod) -> Serializer {
         Serializer {
             ser_method: ser_method,
+            #[cfg(feature = "json")]
             json_serializer: JsonSerializer::new(),
+            #[cfg(feature = "bincode")]
             bincode_serializer: BincodeSerializer::new(),
+            #[cfg(feature = "yaml")]
             yaml_serializer: YamlSerializer::new(),
+            #[cfg(feature = "cbor")]
             cbor_serializer: CborSerializer::new(),
         }
 
@@ -284,9 +294,13 @@ impl Serializer {
             V: DeserializeOwned    
     {
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.deserialize_data(ser_data)
         }
     }
@@ -296,27 +310,39 @@ impl Serializer {
                 V: Serialize
     {
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.serialize_data(data),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.serialize_data(data),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.serialize_data(data),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.serialize_data(data)
         }
     }
 
     pub(crate) fn serialize_db(&self, map: &HashMap<String, Vec<u8>>, list_map: &HashMap<String, Vec<Vec<u8>>>) -> Result<Vec<u8>, String> {
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.serialize_db(map, list_map)
         }
     }
 
     pub(crate) fn deserialize_db(&self, ser_db: &[u8]) -> Result<(HashMap<String, Vec<u8>>, HashMap<String, Vec<Vec<u8>>>), String> {
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.deserialize_db(ser_db)
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,16 +28,9 @@ macro_rules! set_test_rsc {
 }
 
 #[macro_export]
-macro_rules! ser_method {
-    ($ser_method_int:expr) => {
-        SerializationMethod::from($ser_method_int);
-    }
-}
-
-#[macro_export]
 macro_rules! test_setup {
-    ($function_name:expr, $ser_method_int:expr, $db_name:ident) => {
-        let $db_name = format!("{}_{}.db", $function_name, ser_method!($ser_method_int).to_string());
+    ($function_name:expr, $ser_method:expr, $db_name:ident) => {
+        let $db_name = format!("{}_{}.db", $function_name, $ser_method.to_string());
         set_test_rsc!(&$db_name);
     }
 }

--- a/tests/pickledb_advanced_tests.rs
+++ b/tests/pickledb_advanced_tests.rs
@@ -15,16 +15,16 @@ extern crate rstest;
 use rstest::rstest_parametrize;
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn lists_and_values(ser_method_int: i32) {
-    test_setup!("lists_and_values", ser_method_int, db_name);
+fn lists_and_values(ser_method: SerializationMethod) {
+    test_setup!("lists_and_values", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // set a few values
     assert!(db.set("key1", &String::from("val1")).is_ok());
@@ -41,7 +41,7 @@ fn lists_and_values(ser_method_int: i32) {
 
     // read keys and lists
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.get::<String>("key1").unwrap(), String::from("val1"));
         assert_eq!(read_db.get::<i32>("key2").unwrap(), 1);
         assert_eq!(read_db.get::<Vec<i32>>("key3").unwrap(), vec![1,2,3]);
@@ -76,16 +76,16 @@ fn gen_random_string<T: Rng>(rng: &mut T, size: usize) -> String {
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn load_test(ser_method_int: i32) {
-    test_setup!("load_test", ser_method_int, db_name);
+fn load_test(ser_method: SerializationMethod) {
+    test_setup!("load_test", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method);
 
     // number of keys to generate
     let generate_keys = 1000;
@@ -194,7 +194,7 @@ fn load_test(ser_method_int: i32) {
     assert!(db.dump().is_ok());
     
     // read again from file
-    let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
 
     // iterate every key/value_type in map saved before
     for (key, val_type) in map.iter() {

--- a/tests/pickledb_dump_policy_tests.rs
+++ b/tests/pickledb_dump_policy_tests.rs
@@ -10,24 +10,24 @@ extern crate rstest;
 use rstest::rstest_parametrize;
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn auto_dump_poilcy_test(ser_method_int: i32) {
-    test_setup!("auto_dump_poilcy_test", ser_method_int, db_name);
+fn auto_dump_poilcy_test(ser_method: SerializationMethod) {
+    test_setup!("auto_dump_poilcy_test", ser_method, db_name);
 
     // create a DB with AutoDump policy
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // set a key-value pair
     assert!(db.set("key1", &1).is_ok());
 
     // verify the change in the DB
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.get::<i32>("key1").unwrap(), 1);
     }
 
@@ -36,7 +36,7 @@ fn auto_dump_poilcy_test(ser_method_int: i32) {
 
     // verify the change in the DB
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.get::<i32>("key1").is_none());
     }
 
@@ -45,7 +45,7 @@ fn auto_dump_poilcy_test(ser_method_int: i32) {
 
     // verify the change in the DB
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.exists("list1"));
         assert_eq!(read_db.llen("list1"), 0);
     }
@@ -55,7 +55,7 @@ fn auto_dump_poilcy_test(ser_method_int: i32) {
 
     // verify the change in the DB
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.llen("list1"), 3);
     }
 
@@ -64,7 +64,7 @@ fn auto_dump_poilcy_test(ser_method_int: i32) {
 
     // verify the change in the DB
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.llen("list1"), 2);
     }
 
@@ -73,7 +73,7 @@ fn auto_dump_poilcy_test(ser_method_int: i32) {
 
     // verify the change in the DB
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.llen("list1"), 1);
     }
 
@@ -82,27 +82,27 @@ fn auto_dump_poilcy_test(ser_method_int: i32) {
 
     // verify the change in the DB
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(!read_db.exists("list1"));
     }
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn read_only_policy_test(ser_method_int: i32) {
-    test_setup!("read_only_policy_test", ser_method_int, db_name);
+fn read_only_policy_test(ser_method: SerializationMethod) {
+    test_setup!("read_only_policy_test", ser_method, db_name);
 
     // create a DB and set a value
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
     assert!(db.set("key1", &String::from("value1")).is_ok());
 
     // create a read only instance of the same DB
-    let mut read_db1 = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let mut read_db1 = PickleDb::load_read_only(&db_name, ser_method).unwrap();
 
     // set a key-value pair in the read-only DB
     assert!(read_db1.set("key2", &String::from("value2")).is_ok());
@@ -110,7 +110,7 @@ fn read_only_policy_test(ser_method_int: i32) {
 
     // verify the change isn't dumped to the file
     {
-        let read_db2 = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db2 = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db2.exists("key1"));
         assert!(!read_db2.exists("key2"));
     }
@@ -120,7 +120,7 @@ fn read_only_policy_test(ser_method_int: i32) {
 
     // verify the change isn't dumped to the file
     {
-        let read_db2 = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db2 = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db2.exists("key1"));
         assert!(!read_db2.exists("key2"));
     }
@@ -130,35 +130,35 @@ fn read_only_policy_test(ser_method_int: i32) {
 
     // verify the change isn't dumped to the file
     {
-        let read_db2 = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db2 = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db2.exists("key1"));
         assert!(!read_db2.exists("key2"));
     }
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn dump_upon_request_policy_test(ser_method_int: i32) {
-    test_setup!("dump_upon_request_policy_test", ser_method_int, db_name);
+fn dump_upon_request_policy_test(ser_method: SerializationMethod) {
+    test_setup!("dump_upon_request_policy_test", ser_method, db_name);
 
     // create a DB and set a value
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method);
     assert!(db.set("key1", &String::from("value1")).is_ok());
 
     // verify file is not yet created
-    assert!(PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).is_err());
+    assert!(PickleDb::load_read_only(&db_name, ser_method).is_err());
 
     // dump to file
     assert!(db.dump().is_ok());
 
     // verify the change is dumped to the file
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.exists("key1"));
     }
 
@@ -170,34 +170,34 @@ fn dump_upon_request_policy_test(ser_method_int: i32) {
 
     // verify the change is dumped to the file
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.exists("key1"));
         assert!(read_db.exists("key2"));
     }
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn periodic_dump_policy_test(ser_method_int: i32) {
-    test_setup!("periodic_dump_policy_test", ser_method_int, db_name);
+fn periodic_dump_policy_test(ser_method: SerializationMethod) {
+    test_setup!("periodic_dump_policy_test", ser_method, db_name);
 
     // create a DB and set a value
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::PeriodicDump(Duration::new(1, 0)), ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::PeriodicDump(Duration::new(1, 0)), ser_method);
     assert!(db.set("key1", &String::from("value1")).is_ok());
 
     // verify file is not yet created
-    assert!(PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).is_err());
+    assert!(PickleDb::load_read_only(&db_name, ser_method).is_err());
 
     // sleep for 0.5 sec
     thread::sleep(time::Duration::from_millis(500));
 
     // verify file is not yet created
-    assert!(PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).is_err());
+    assert!(PickleDb::load_read_only(&db_name, ser_method).is_err());
 
     // sleep for 0.55 sec
     thread::sleep(time::Duration::from_millis(550));
@@ -207,7 +207,7 @@ fn periodic_dump_policy_test(ser_method_int: i32) {
 
     // verify the change is dumped to the file
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.exists("key1"));
         assert!(read_db.exists("key2"));
     }
@@ -217,7 +217,7 @@ fn periodic_dump_policy_test(ser_method_int: i32) {
 
     // verify the change is not yet dumped to the file
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(!read_db.exists("key3"));
     }
 
@@ -226,7 +226,7 @@ fn periodic_dump_policy_test(ser_method_int: i32) {
 
     // verify the change is now dumped to the file
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.exists("key3"));
     }
 
@@ -238,7 +238,7 @@ fn periodic_dump_policy_test(ser_method_int: i32) {
 
     // verify the change is dumped to the file
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.exists("key4"));
     }
 
@@ -250,7 +250,7 @@ fn periodic_dump_policy_test(ser_method_int: i32) {
 
     // verify the change is dumped to the file
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert!(read_db.exists("key5"));
     }
 }

--- a/tests/pickledb_error_tests.rs
+++ b/tests/pickledb_error_tests.rs
@@ -10,6 +10,10 @@ use std::fs::File;
 
 mod common;
 
+#[cfg(feature = "json")]
+#[cfg(feature = "bincode")]
+#[cfg(feature = "cbor")]
+#[cfg(feature = "yaml")]
 #[test]
 fn load_serialization_error_test() {
     set_test_rsc!("json_db.db");
@@ -42,6 +46,7 @@ fn load_serialization_error_test() {
     assert!(PickleDb::load_yaml("json_db.db", PickleDbDumpPolicy::NeverDump).is_ok());
 }
 
+#[cfg(feature = "bincode")]
 #[test]
 fn load_error_test() {
 

--- a/tests/pickledb_key_value_tests.rs
+++ b/tests/pickledb_key_value_tests.rs
@@ -11,16 +11,16 @@ extern crate rstest;
 use rstest::rstest_parametrize;
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn basic_set_get(ser_method_int: i32) {
-    test_setup!("basic_set_get", ser_method_int, db_name);
+fn basic_set_get(ser_method: SerializationMethod) {
+    test_setup!("basic_set_get", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // set a number
     let num = 100;
@@ -64,17 +64,17 @@ fn basic_set_get(ser_method_int: i32) {
 
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn set_load_get(ser_method_int: i32) {
-    test_setup!("set_load_get", ser_method_int, db_name);
+fn set_load_get(ser_method: SerializationMethod) {
+    test_setup!("set_load_get", ser_method, db_name);
 
     // create a db with auto_dump == false
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method);
 
     // set a number
     let num = 100;
@@ -107,7 +107,7 @@ fn set_load_get(ser_method_int: i32) {
     assert!(db.dump().is_ok());
 
     // read db from file
-    let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
 
     // read a num
     assert_eq!(read_db.get::<i32>("num").unwrap(), num);
@@ -124,17 +124,17 @@ fn set_load_get(ser_method_int: i32) {
 
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn set_load_get_auto_dump(ser_method_int: i32) {
-    test_setup!("set_load_get_auto_dump", ser_method_int, db_name);
+fn set_load_get_auto_dump(ser_method: SerializationMethod) {
+    test_setup!("set_load_get_auto_dump", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // set a number
     let num = 100;
@@ -163,7 +163,7 @@ fn set_load_get_auto_dump(ser_method_int: i32) {
     db.set("struct", &mycoor).unwrap();
 
 
-    let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
 
     // read a num
     assert_eq!(read_db.get::<i32>("num").unwrap(), num);
@@ -178,18 +178,19 @@ fn set_load_get_auto_dump(ser_method_int: i32) {
     assert_eq!(read_db.get::<Coor>("struct").unwrap().y, mycoor.y);
 }
 
+#[cfg(feature = "bincode")]
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn set_load_get_auto_dump2(ser_method_int: i32) {
-    test_setup!("set_load_get_auto_dump2", ser_method_int, db_name);
+fn set_load_get_auto_dump2(ser_method: SerializationMethod) {
+    test_setup!("set_load_get_auto_dump2", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // set a number
     let num = 100;
@@ -197,7 +198,7 @@ fn set_load_get_auto_dump2(ser_method_int: i32) {
 
     // read this number immediately
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.get::<i32>("num").unwrap(), num);
     }
 
@@ -207,7 +208,7 @@ fn set_load_get_auto_dump2(ser_method_int: i32) {
 
     // read this other number immediately
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.get::<i32>("num2").unwrap(), num2);
     }
 
@@ -217,7 +218,7 @@ fn set_load_get_auto_dump2(ser_method_int: i32) {
     // read the new value
     assert_eq!(db.get::<i32>("num").unwrap(), 101);
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.get::<i32>("num").unwrap(), 101);
     }
 
@@ -225,30 +226,30 @@ fn set_load_get_auto_dump2(ser_method_int: i32) {
     db.set("num", &vec![1,2,3]).unwrap();
 
     // read the new value
-    if let SerializationMethod::Bin = ser_method!(ser_method_int) {
+    if let SerializationMethod::Bin = ser_method {
         // N/A
     } else {
         assert!(db.get::<i32>("num").is_none());
     }
     assert_eq!(db.get::<Vec<i32>>("num").unwrap(), vec![1,2,3]);
     {
-        let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
         assert_eq!(read_db.get::<Vec<i32>>("num").unwrap(), vec![1,2,3]);
     }
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn set_special_strings(ser_method_int: i32) {
-    test_setup!("set_special_strings", ser_method_int, db_name);
+fn set_special_strings(ser_method: SerializationMethod) {
+    test_setup!("set_special_strings", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     db.set("string1", &String::from("\"dobule_quotes\"")).unwrap();
     db.set("string2", &String::from("\'single_quotes\'")).unwrap();
@@ -257,7 +258,7 @@ fn set_special_strings(ser_method_int: i32) {
     db.set("string5", &String::from("\nescapes\t\r")).unwrap();
     db.set("string6", &String::from("my\\folder")).unwrap();
 
-    let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
     assert_eq!(read_db.get::<String>("string1").unwrap(), String::from("\"dobule_quotes\""));
     assert_eq!(read_db.get::<String>("string2").unwrap(), String::from("\'single_quotes\'"));
     assert_eq!(read_db.get::<String>("string3").unwrap(), String::from("שָׁלוֹם"));
@@ -266,48 +267,49 @@ fn set_special_strings(ser_method_int: i32) {
     assert_eq!(read_db.get::<String>("string6").unwrap(), String::from("my\\folder"));
 }
 
+#[cfg(feature = "yaml")]
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn edge_cases(ser_method_int: i32) {
-    test_setup!("edge_cases", ser_method_int, db_name);
+fn edge_cases(ser_method: SerializationMethod) {
+    test_setup!("edge_cases", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     let x = 123;
     db.set("num", &x).unwrap();
 
     // load a read only version of the db from file
-    let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
 
     assert_eq!(db.get::<i32>("num"), Some(x));
     assert_eq!(read_db.get::<i32>("num"), Some(x));
-    if let SerializationMethod::Yaml = ser_method!(ser_method_int) {
+    if let SerializationMethod::Yaml = ser_method {
         // N/A
     } else {
-        assert_eq!(db.get::<String>("num"), None);        
+        assert_eq!(db.get::<String>("num"), None);
         assert_eq!(read_db.get::<String>("num"), None);
     }
 
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn get_all_keys(ser_method_int: i32) {
-    test_setup!("get_all_keys", ser_method_int, db_name);
+fn get_all_keys(ser_method: SerializationMethod) {
+    test_setup!("get_all_keys", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // insert 10 keys: key0..key9
     let num = 100;
@@ -331,17 +333,17 @@ fn get_all_keys(ser_method_int: i32) {
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn rem_keys(ser_method_int: i32) {
-    test_setup!("rem_keys", ser_method_int, db_name);
+fn rem_keys(ser_method: SerializationMethod) {
+    test_setup!("rem_keys", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // insert 10 keys: key0..key9
     let num = 100;
@@ -367,22 +369,22 @@ fn rem_keys(ser_method_int: i32) {
     }
 
     // verify keys were also removed from the file
-    let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
     assert_eq!(read_db.total_keys(), 8);
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn iter_test(ser_method_int: i32) {
-    test_setup!("iter_test", ser_method_int, db_name);
+fn iter_test(ser_method: SerializationMethod) {
+    test_setup!("iter_test", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     let keys = vec!["key1", "key2", "key3", "key4", "key5"];
     // add a few keys and values

--- a/tests/pickledb_list_tests.rs
+++ b/tests/pickledb_list_tests.rs
@@ -11,16 +11,16 @@ extern crate rstest;
 use rstest::rstest_parametrize;
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn basic_lists(ser_method_int: i32) {
-    test_setup!("basic_lists", ser_method_int, db_name);
+fn basic_lists(ser_method: SerializationMethod) {
+    test_setup!("basic_lists", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     db.lcreate("list1").unwrap();
 
@@ -92,7 +92,7 @@ fn basic_lists(ser_method_int: i32) {
 
 
     // load the file as read only db
-    let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
 
     // verify lists length
     assert_eq!(read_db.llen("list1"), 5);
@@ -122,16 +122,16 @@ fn basic_lists(ser_method_int: i32) {
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn add_and_extend_lists(ser_method_int: i32) {
-    test_setup!("add_and_extend_lists", ser_method_int, db_name);
+fn add_and_extend_lists(ser_method: SerializationMethod) {
+    test_setup!("add_and_extend_lists", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // create 3 lists
     db.lcreate("list1").unwrap();
@@ -168,7 +168,7 @@ fn add_and_extend_lists(ser_method_int: i32) {
     }
 
     // read db from file
-    let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
 
     // check all values in all lists
     for x in 0..5 {
@@ -179,16 +179,16 @@ fn add_and_extend_lists(ser_method_int: i32) {
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn override_lists(ser_method_int: i32) {
-    test_setup!("override_lists", ser_method_int, db_name);
+fn override_lists(ser_method: SerializationMethod) {
+    test_setup!("override_lists", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // create a list and add some values to it
     db.lcreate("list1").unwrap()
@@ -206,7 +206,7 @@ fn override_lists(ser_method_int: i32) {
 
     // read the list from file and verify the same
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert!(read_db.lexists("list1"));
         assert_eq!(read_db.llen("list1"), 0);
     }
@@ -220,23 +220,24 @@ fn override_lists(ser_method_int: i32) {
 
     // read the list from file and verify the same
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert!(read_db.lexists("list1"));
         assert_eq!(read_db.llen("list1"), 4);
     }
 }
 
+#[cfg(feature = "bincode")]
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn lget_corner_cases(ser_method_int: i32) {
-    test_setup!("lget_corner_cases", ser_method_int, db_name);
+fn lget_corner_cases(ser_method: SerializationMethod) {
+    test_setup!("lget_corner_cases", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method);
 
     // create a list and add some values
     db.lcreate("list1").unwrap()
@@ -248,13 +249,13 @@ fn lget_corner_cases(ser_method_int: i32) {
     assert_eq!(db.lget::<i32>("list1", 4).unwrap(), 100);
 
     // lget values that exist but in the wrong type
-    if let SerializationMethod::Bin = ser_method!(ser_method_int) {
+    if let SerializationMethod::Bin = ser_method {
         // N/A
     } else {
         assert!(db.lget::<i32>("list1", 0).is_none());
         assert!(db.lget::<Vec<i32>>("list1", 0).is_none());
 
-        if let SerializationMethod::Yaml = ser_method!(ser_method_int) {
+        if let SerializationMethod::Yaml = ser_method {
             // N/A
         }
         else {
@@ -272,16 +273,16 @@ fn lget_corner_cases(ser_method_int: i32) {
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn add_to_non_existent_list(ser_method_int: i32) {
-    test_setup!("lget_corner_cases", ser_method_int, db_name);
+fn add_to_non_existent_list(ser_method: SerializationMethod) {
+    test_setup!("lget_corner_cases", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::DumpUponRequest, ser_method);
 
     let num = 100;
     let vec_of_nums = vec![1,2,3];
@@ -310,16 +311,16 @@ fn add_to_non_existent_list(ser_method_int: i32) {
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn remove_list(ser_method_int: i32) {
-    test_setup!("remove_list", ser_method_int, db_name);
+fn remove_list(ser_method: SerializationMethod) {
+    test_setup!("remove_list", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // create some lists add add values to them
     db.lcreate("list1").unwrap()
@@ -336,7 +337,7 @@ fn remove_list(ser_method_int: i32) {
 
     // verify number of lists in file
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert_eq!(read_db.total_keys(), 4);
     }
 
@@ -348,7 +349,7 @@ fn remove_list(ser_method_int: i32) {
 
     // verify number of lists in file
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert_eq!(read_db.total_keys(), 3);
     }
 
@@ -361,22 +362,22 @@ fn remove_list(ser_method_int: i32) {
 
     // verify number of lists in file
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert_eq!(read_db.total_keys(), 2);
     }
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn remove_values_from_list(ser_method_int: i32) {
-    test_setup!("remove_values_from_list", ser_method_int, db_name);
+fn remove_values_from_list(ser_method: SerializationMethod) {
+    test_setup!("remove_values_from_list", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // add a struct to list1
     #[derive(Serialize, Deserialize, Debug)]
@@ -407,7 +408,7 @@ fn remove_values_from_list(ser_method_int: i32) {
 
     // read this from file as well
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert_eq!(read_db.lget::<MySquare>("list1", 4).unwrap().x, 4);
         assert_eq!(read_db.lget::<String>("list1", 3).unwrap(), "hello");
     }
@@ -434,7 +435,7 @@ fn remove_values_from_list(ser_method_int: i32) {
 
     // read this from file as well
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert_eq!(read_db.lget::<MySquare>("list1", 3).unwrap().x, 10);
         assert_eq!(read_db.lget::<i32>("list1", 1).unwrap(), 3);
     }
@@ -451,23 +452,23 @@ fn remove_values_from_list(ser_method_int: i32) {
 
     // read this from file as well
     {
-        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method!(ser_method_int)).unwrap();
+        let read_db = PickleDb::load(&db_name, PickleDbDumpPolicy::NeverDump, ser_method).unwrap();
         assert_eq!(read_db.lget::<MySquare>("list1", 2).unwrap().x, 10);
         assert_eq!(read_db.lget::<i32>("list1", 0).unwrap(), 2);
     }
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn list_with_special_strings(ser_method_int: i32) {
-    test_setup!("list_with_special_strings", ser_method_int, db_name);
+fn list_with_special_strings(ser_method: SerializationMethod) {
+    test_setup!("list_with_special_strings", ser_method, db_name);
 
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     // create a list and add special strings to it
     db.lcreate("list1").unwrap()
@@ -487,7 +488,7 @@ fn list_with_special_strings(ser_method_int: i32) {
     assert_eq!(db.lget::<String>("list1", 5).unwrap(), String::from("my\\folder"));
 
     // load db from file
-    let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
+    let read_db = PickleDb::load_read_only(&db_name, ser_method).unwrap();
 
     // read strgins from list loaded from file
     assert_eq!(read_db.lget::<String>("list1", 0).unwrap(), String::from("\"dobule_quotes\""));
@@ -499,17 +500,17 @@ fn list_with_special_strings(ser_method_int: i32) {
 }
 
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn list_iter_test(ser_method_int: i32) {
-    test_setup!("list_iter_test", ser_method_int, db_name);
+fn list_iter_test(ser_method: SerializationMethod) {
+    test_setup!("list_iter_test", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     let values = (1, 1.1, String::from("value"), vec![1,2,3], ('a', 'b', 'c'));
 
@@ -543,17 +544,17 @@ fn list_iter_test(ser_method_int: i32) {
 
 #[should_panic]
 #[rstest_parametrize(
-    ser_method_int,
-    case(0),
-    case(1),
-    case(2),
-    case(3)
+    ser_method,
+    case(SerializationMethod::Json),
+    case(SerializationMethod::Bin),
+    case(SerializationMethod::Yaml),
+    case(SerializationMethod::Cbor)
 )]
-fn list_doesnt_exist_iter_test(ser_method_int: i32) {
-    test_setup!("list_doesnt_exist_iter_test", ser_method_int, db_name);
+fn list_doesnt_exist_iter_test(ser_method: SerializationMethod) {
+    test_setup!("list_doesnt_exist_iter_test", ser_method, db_name);
 
     // create a db with auto_dump == true
-    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method!(ser_method_int));
+    let mut db = PickleDb::new(&db_name, PickleDbDumpPolicy::AutoDump, ser_method);
 
     let values = (1, 1.1, String::from("value"), vec![1,2,3], ('a', 'b', 'c'));
 


### PR DESCRIPTION
I added features for the different serialization methods, to lower the library size and necessary dependencies. Default is json. Unfortunately running the tests is only possible using all features, because of the parameterized rstests. Maybe you have an idea how to solve this problem.