### PR TITLE
Make the examples runnable by cargo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
-examples/**/target
-examples/**/*.db
+*.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,4 @@ os:
   - windows
 
 script:
-- cargo test
-- cargo build --manifest-path=examples/hello_world/Cargo.toml
-- cargo build --manifest-path=examples/lists/Cargo.toml
+  - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,11 @@ rand = "0.6.3"
 rstest = "0.2.2"
 matches = "0.1.8"
 fs2 = "0.4.3"
+
+[[example]]
+name = "hello_world"
+path = "examples/hello_world/src/main.rs"
+
+[[example]]
+name = "lists"
+path = "examples/lists/src/main.rs"


### PR DESCRIPTION
This allows us to run the examples by calling e.g.
'cargo run --example hello_world'

It also means the examples get compiled when calling 'cargo test'.