### PR TITLE
Bumping versions due to a flaw found in serde_cbor-0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pickledb"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["seladb <pcapplusplus@gmail.com>"]
 license = "MIT"
 readme = "README.md"
@@ -16,17 +16,17 @@ edition = "2018"
 travis-ci = { repository = "seladb/pickledb-rs" }
 
 [dependencies]
-serde = { version = "1.0.82", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-bincode = "1.0.1"
-serde_yaml = "0.8.8"
-serde_cbor = "0.9.0"
+bincode = "1.0"
+serde_yaml = "0.8"
+serde_cbor = "0.11"
 
 [dev-dependencies]
-rand = "0.6.3"
-rstest = "0.2.2"
-matches = "0.1.8"
-fs2 = "0.4.3"
+rand = "0.6"
+rstest = "0.2"
+matches = "0.1"
+fs2 = "0.4"
 
 [[example]]
 name = "hello_world"


### PR DESCRIPTION
Flaw found in transitive dependency failed my build
https://travis-ci.org/github/jensim/bitbucket_server_cli/builds/667567270
I added a audit step to the build as well, if you think its smart?