### PR TITLE
Perform cargo audit on nightly builds & do CI in github actions

### DIFF
--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -1,0 +1,22 @@
+name: Rust audit
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install cargo-audit
+      run: cargo install --force cargo-audit
+    - name: Generate lockfile
+      run: cargo generate-lockfile
+    - name: Perform audit
+      run: cargo audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,49 @@
+name: Rust test
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable, nightly, beta]
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --examples --lib --bins
+      - name: Test
+        run: cargo test --verbose --examples --lib --bins
+  clippy:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Run clippy
+        run: cargo clippy --all-targets -- --deny clippy::all
+  fmt:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta]
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+      - uses: actions/checkout@v2
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+      - name: Run rustfmt
+        run: cargo fmt -- --check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PickleDB
 
 [![Build Status](https://api.travis-ci.org/seladb/pickledb-rs.svg?branch=master)](https://travis-ci.org/seladb/pickledb-rs)
+[![Rust test](https://github.com/seladb/pickledb-rs/workflows/Rust%20test/badge.svg)](https://github.com/seladb/pickledb-rs/actions?query=workflow%3A%22Rust+test%22)
+[![Rust audit](https://github.com/seladb/pickledb-rs/workflows/Rust%20audit/badge.svg)](https://github.com/seladb/pickledb-rs/actions?query=workflow%3A%22Rust+audit%22)
 [![Crate](https://img.shields.io/crates/v/pickledb.svg)](https://crates.io/crates/pickledb)
 [![API](https://docs.rs/pickledb/badge.svg)](https://docs.rs/pickledb)
 


### PR DESCRIPTION
Hi again @seladb =)
I beleive we talked briefly about doing cargo audit in CI. Well now I've set it up for my little project over at https://github.com/jensim/bitbucket_server_cli and i think it works great so far. 
Wanna try it out?
Best regards
Jens