### PR TITLE
`DumpUponRequest` policy no longer dumps on `Drop`

### DIFF
--- a/src/pickledb.rs
+++ b/src/pickledb.rs
@@ -1052,8 +1052,10 @@ impl PickleDb {
 
 impl Drop for PickleDb {
     fn drop(&mut self) {
-        if let PickleDbDumpPolicy::NeverDump = self.dump_policy {
-        } else {
+        if !matches!(
+            self.dump_policy,
+            PickleDbDumpPolicy::NeverDump | PickleDbDumpPolicy::DumpUponRequest
+        ) {
             // try to dump, ignore if fails
             let _ = self.dump();
         }

--- a/tests/pickledb_dump_policy_tests.rs
+++ b/tests/pickledb_dump_policy_tests.rs
@@ -162,11 +162,11 @@ fn dump_upon_request_policy_test(ser_method_int: i32) {
     // drop DB object
     drop(db);
 
-    // verify the change is dumped to the file
+    // verify the change is not dumped to the file
     {
         let read_db = PickleDb::load_read_only(&db_name, ser_method!(ser_method_int)).unwrap();
         assert!(read_db.exists("key1"));
-        assert!(read_db.exists("key2"));
+        assert!(!read_db.exists("key2"));
     }
 }
 


### PR DESCRIPTION
I was surprised to discover that `PickleDbDumpPolicy::DumpUponRequest` still causes a dump on `Drop`.  <s>It's not clear to me if this is intentional or a bug, so for now I propose a new policy that removes this unexpected implicit dump for applications that wish to opt-in while retaining the existing behaviour for other users of `PickleDbDumpPolicy::DumpUponRequest`.</s>

This PR removes this unexpected dump.