### PR TITLE
Allow turning off file formats with features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install clippy
         run: rustup component add clippy
       - name: Run clippy
-        run: cargo clippy --all-targets -- --deny clippy::all
+        run: cargo clippy --all-targets --all-features -- --deny clippy::all
   fmt:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,24 @@ travis-ci = { repository = "seladb/pickledb-rs" }
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-bincode = "1.0"
-serde_yaml = "0.8"
-serde_cbor = "0.11"
+
+serde_json = { version = "1.0", optional = true }
+bincode = { version = "1.0", optional = true }
+serde_yaml = { version = "0.8", optional = true }
+serde_cbor = { version = "0.11", optional = true }
 
 [dev-dependencies]
 rand = "0.6"
 rstest = "0.2"
 matches = "0.1"
 fs2 = "0.4"
+
+[features]
+default = ["json"]
+json = ["dep:serde_json"]
+bincode = ["dep:bincode"]
+yaml = ["dep:serde_yaml"]
+cbor = ["dep:serde_cbor"]
 
 [[example]]
 name = "hello_world"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ rstest = "0.2"
 matches = "0.1"
 fs2 = "0.4"
 
-# 'bincode' feature created implicitly
 [features]
 default = ["json"]
 json = ["dep:serde_json"]
+bincode = ["dep:bincode"]
 yaml = ["dep:serde_yaml"]
 cbor = ["dep:serde_cbor"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ rstest = "0.2"
 matches = "0.1"
 fs2 = "0.4"
 
+# 'bincode' feature created implicitly
 [features]
 default = ["json"]
 json = ["dep:serde_json"]
-bincode = ["dep:bincode"]
 yaml = ["dep:serde_yaml"]
 cbor = ["dep:serde_cbor"]
 

--- a/examples/lists/Cargo.toml
+++ b/examples/lists/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["seladb <pcapplusplus@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-pickledb = { path = "../../" }
+pickledb = { path = "../../", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.82", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,10 @@
 //! * [YAML serialization](https://crates.io/crates/serde_yaml)
 //! * [CBOR serialization](https://crates.io/crates/serde_cbor)
 //!
+//! The serialization types are enabled and disabled with features (`json` (enabled by default), `bincode`, `yaml`, and `cbor`).
+//! To enable them, just add their names to the `features` list when declaring the dependency. To disable JSON, set `default-features` to false.
+//! For instance, `pickledb = { version = "0.5", features = ["cbor", "yaml"], default-features = false }` would enable CBOR and YAML only.
+//!
 //! The user can choose a serialization type to use upon creating a DB or loading it from a file.
 //!
 //! So what does it mean that all objects must be serializable? That means that all objects that you use must be serializable.

--- a/src/pickledb.rs
+++ b/src/pickledb.rs
@@ -526,7 +526,7 @@ impl PickleDb {
         V: DeserializeOwned,
     {
         match self.map.get(key) {
-            Some(val) => self.serializer.deserialize_data::<V>(&val),
+            Some(val) => self.serializer.deserialize_data::<V>(val),
             None => None,
         }
     }
@@ -801,7 +801,7 @@ impl PickleDb {
     {
         match self.list_map.get(name) {
             Some(list) => match list.get(pos) {
-                Some(val) => self.serializer.deserialize_data::<V>(&val),
+                Some(val) => self.serializer.deserialize_data::<V>(val),
                 None => None,
             },
             None => None,

--- a/src/pickledb.rs
+++ b/src/pickledb.rs
@@ -87,6 +87,7 @@ impl PickleDb {
     /// let mut db = PickleDb::new_json("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "json")]
     pub fn new_json<P: AsRef<Path>>(db_path: P, dump_policy: PickleDbDumpPolicy) -> PickleDb {
         PickleDb::new(db_path, dump_policy, SerializationMethod::Json)
     }
@@ -107,6 +108,7 @@ impl PickleDb {
     /// let mut db = PickleDb::new_bin("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "bincode")]
     pub fn new_bin<P: AsRef<Path>>(db_path: P, dump_policy: PickleDbDumpPolicy) -> PickleDb {
         PickleDb::new(db_path, dump_policy, SerializationMethod::Bin)
     }
@@ -127,6 +129,7 @@ impl PickleDb {
     /// let mut db = PickleDb::new_yaml("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "yaml")]
     pub fn new_yaml<P: AsRef<Path>>(db_path: P, dump_policy: PickleDbDumpPolicy) -> PickleDb {
         PickleDb::new(db_path, dump_policy, SerializationMethod::Yaml)
     }
@@ -147,6 +150,7 @@ impl PickleDb {
     /// let mut db = PickleDb::new_cbor("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "cbor")]
     pub fn new_cbor<P: AsRef<Path>>(db_path: P, dump_policy: PickleDbDumpPolicy) -> PickleDb {
         PickleDb::new(db_path, dump_policy, SerializationMethod::Cbor)
     }
@@ -231,6 +235,7 @@ impl PickleDb {
     /// let db = PickleDb::load_json("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "json")]
     pub fn load_json<P: AsRef<Path>>(
         db_path: P,
         dump_policy: PickleDbDumpPolicy,
@@ -257,6 +262,7 @@ impl PickleDb {
     /// let db = PickleDb::load_bin("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "bincode")]
     pub fn load_bin<P: AsRef<Path>>(
         db_path: P,
         dump_policy: PickleDbDumpPolicy,
@@ -283,6 +289,7 @@ impl PickleDb {
     /// let db = PickleDb::load_yaml("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "yaml")]
     pub fn load_yaml<P: AsRef<Path>>(
         db_path: P,
         dump_policy: PickleDbDumpPolicy,
@@ -309,6 +316,7 @@ impl PickleDb {
     /// let db = PickleDb::load_cbor("example.db", PickleDbDumpPolicy::AutoDump);
     /// ```
     ///
+    #[cfg(feature = "cbor")]
     pub fn load_cbor<P: AsRef<Path>>(
         db_path: P,
         dump_policy: PickleDbDumpPolicy,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -40,8 +40,10 @@ impl fmt::Display for SerializationMethod {
     }
 }
 
+#[cfg(feature = "json")]
 struct JsonSerializer {}
 
+#[cfg(feature = "json")]
 impl JsonSerializer {
     fn new() -> JsonSerializer {
         JsonSerializer {}
@@ -113,8 +115,10 @@ impl JsonSerializer {
     }
 }
 
+#[cfg(feature = "yaml")]
 struct YamlSerializer {}
 
+#[cfg(feature = "yaml")]
 impl YamlSerializer {
     fn new() -> YamlSerializer {
         YamlSerializer {}
@@ -186,8 +190,10 @@ impl YamlSerializer {
     }
 }
 
+#[cfg(feature = "bincode")]
 struct BincodeSerializer {}
 
+#[cfg(feature = "bincode")]
 impl BincodeSerializer {
     fn new() -> BincodeSerializer {
         BincodeSerializer {}
@@ -225,8 +231,10 @@ impl BincodeSerializer {
     }
 }
 
+#[cfg(feature = "cbor")]
 struct CborSerializer {}
 
+#[cfg(feature = "cbor")]
 impl CborSerializer {
     fn new() -> CborSerializer {
         CborSerializer {}
@@ -266,9 +274,13 @@ impl CborSerializer {
 
 pub(crate) struct Serializer {
     ser_method: SerializationMethod,
+    #[cfg(feature = "json")]
     json_serializer: JsonSerializer,
+    #[cfg(feature = "bincode")]
     bincode_serializer: BincodeSerializer,
+    #[cfg(feature = "yaml")]
     yaml_serializer: YamlSerializer,
+    #[cfg(feature = "cbor")]
     cbor_serializer: CborSerializer,
 }
 
@@ -276,9 +288,13 @@ impl Serializer {
     pub(crate) fn new(ser_method: SerializationMethod) -> Serializer {
         Serializer {
             ser_method,
+            #[cfg(feature = "json")]
             json_serializer: JsonSerializer::new(),
+            #[cfg(feature = "bincode")]
             bincode_serializer: BincodeSerializer::new(),
+            #[cfg(feature = "yaml")]
             yaml_serializer: YamlSerializer::new(),
+            #[cfg(feature = "cbor")]
             cbor_serializer: CborSerializer::new(),
         }
     }
@@ -287,11 +303,23 @@ impl Serializer {
     where
         V: DeserializeOwned,
     {
+        #[allow(unreachable_patterns)]
         match self.ser_method {
             SerializationMethod::Json => self.json_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "json")]
+            _ => self.json_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "bincode")]
+            _ => self.bincode_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "yaml")]
+            _ => self.yaml_serializer.deserialize_data(ser_data),
+            #[cfg(feature = "cbor")]
+            _ => self.cbor_serializer.deserialize_data(ser_data),
         }
     }
 
@@ -299,11 +327,24 @@ impl Serializer {
     where
         V: Serialize,
     {
+        #[allow(unreachable_patterns)]
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.serialize_data(data),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.serialize_data(data),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.serialize_data(data),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.serialize_data(data),
+            #[cfg(feature = "json")]
+            _ => self.json_serializer.serialize_data(data),
+            #[cfg(feature = "bincode")]
+            _ => self.bincode_serializer.serialize_data(data),
+            #[cfg(feature = "yaml")]
+            _ => self.yaml_serializer.serialize_data(data),
+            #[cfg(feature = "cbor")]
+            _ => self.cbor_serializer.serialize_data(data),
         }
     }
 
@@ -312,20 +353,46 @@ impl Serializer {
         map: &DbMap,
         list_map: &DbListMap,
     ) -> Result<Vec<u8>, String> {
+        #[allow(unreachable_patterns)]
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "json")]
+            _ => self.json_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "bincode")]
+            _ => self.bincode_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "yaml")]
+            _ => self.yaml_serializer.serialize_db(map, list_map),
+            #[cfg(feature = "cbor")]
+            _ => self.cbor_serializer.serialize_db(map, list_map),
         }
     }
 
     pub(crate) fn deserialize_db(&self, ser_db: &[u8]) -> Result<(DbMap, DbListMap), String> {
+        #[allow(unreachable_patterns)]
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "yaml")]
             SerializationMethod::Yaml => self.yaml_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "cbor")]
             SerializationMethod::Cbor => self.cbor_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "json")]
+            _ => self.json_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "bincode")]
+            _ => self.bincode_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "yaml")]
+            _ => self.yaml_serializer.deserialize_db(ser_db),
+            #[cfg(feature = "cbor")]
+            _ => self.cbor_serializer.deserialize_db(ser_db),
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,7 +32,7 @@ macro_rules! set_test_rsc {
 #[macro_export]
 macro_rules! ser_method {
     ($ser_method_int:expr) => {
-        SerializationMethod::from($ser_method_int);
+        SerializationMethod::from($ser_method_int)
     };
 }
 

--- a/tests/pickledb_advanced_tests.rs
+++ b/tests/pickledb_advanced_tests.rs
@@ -211,7 +211,9 @@ fn load_test(ser_method_int: i32) {
         // verify key exists in db
         assert!(
             read_db.exists(&key),
-            format!("Key {} of type {} isn't found", key, val_type)
+            "Key {} of type {} isn't found",
+            key,
+            val_type
         );
 
         // get the value according to the value_type saved

--- a/tests/pickledb_advanced_tests.rs
+++ b/tests/pickledb_advanced_tests.rs
@@ -210,7 +210,7 @@ fn load_test(ser_method_int: i32) {
     for (key, val_type) in map.iter() {
         // verify key exists in db
         assert!(
-            read_db.exists(&key),
+            read_db.exists(key),
             "Key {} of type {} isn't found",
             key,
             val_type
@@ -218,11 +218,11 @@ fn load_test(ser_method_int: i32) {
 
         // get the value according to the value_type saved
         match *val_type {
-            "i32" => assert!(read_db.get::<i32>(&key).is_some()),
-            "f32" => assert!(read_db.get::<f32>(&key).is_some()),
-            "string" => assert!(read_db.get::<String>(&key).is_some()),
-            "vec" => assert!(read_db.get::<Vec<i32>>(&key).is_some()),
-            "list" => assert!(read_db.lexists(&key)),
+            "i32" => assert!(read_db.get::<i32>(key).is_some()),
+            "f32" => assert!(read_db.get::<f32>(key).is_some()),
+            "string" => assert!(read_db.get::<String>(key).is_some()),
+            "vec" => assert!(read_db.get::<Vec<i32>>(key).is_some()),
+            "list" => assert!(read_db.lexists(key)),
             _ => (),
         }
     }

--- a/tests/pickledb_key_value_tests.rs
+++ b/tests/pickledb_key_value_tests.rs
@@ -353,7 +353,7 @@ fn rem_keys(ser_method_int: i32) {
 
     // verify both keys were removed
     for i in vec![5, 8].iter() {
-        assert_eq!(db.exists(&format!("{}{}", "key", i)), false);
+        assert!(!db.exists(&format!("{}{}", "key", i)));
     }
 
     // verify the other keys are still there


### PR DESCRIPTION
Resolves #23 

Not sure I like how I had to handle most of the match blocks, since I couldn't find an easy way to disable enum fields with features, but it works. Brings size of `hello_world` example from 1.2 MB to 670 KB, and `lists` from 1.2 MB to 673 KB on macOS.