### PR TITLE
Add missing JSON feature gate

### DIFF
--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -305,6 +305,7 @@ impl Serializer {
     {
         #[allow(unreachable_patterns)]
         match self.ser_method {
+            #[cfg(feature = "json")]
             SerializationMethod::Json => self.json_serializer.deserialize_data(ser_data),
             #[cfg(feature = "bincode")]
             SerializationMethod::Bin => self.bincode_serializer.deserialize_data(ser_data),


### PR DESCRIPTION
So... Turns out I forgot one `cfg` expression, and the crate doesn't compile with `json` turned off. Strange, because the `lists` example works fine, even without this.