### PR TITLE
Use implicit feature names for stable Rust support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,9 @@ fs2 = "0.4"
 
 [features]
 default = ["json"]
-json = ["dep:serde_json"]
-bincode = ["dep:bincode"]
-yaml = ["dep:serde_yaml"]
-cbor = ["dep:serde_cbor"]
+json = ["serde_json"]
+yaml = ["serde_yaml"]
+cbor = ["serde_cbor"]
 
 [[example]]
 name = "hello_world"


### PR DESCRIPTION
From the [Cargo docs](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies): "The dep: syntax is only available starting with Rust 1.60. Previous versions can only use the implicit feature name."