### PR TITLE
Addition of Nanoserde backend for smaller dependency tree and faster compile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,8 +28,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- --deny clippy::all
+      - name: Run clippy serde
+        run: cargo clippy --all-targets --features "json cbor yaml bincode" -- --deny clippy::all
+      - name: Run clippy nano
+        run: cargo clippy --all-targets --no-default-features --features "nano" -- --deny clippy::all
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,13 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "seladb/pickledb-rs" }
 
-[dependencies]
-serde = { version = "1.0", features = ["derive"] }
+[lib]
+doctest = false
 
+[dependencies]
+nanoserde = { version = "0.1.30", optional = true }
+
+serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 bincode = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8", optional = true }
@@ -31,10 +35,12 @@ fs2 = "0.4"
 
 [features]
 default = ["json"]
-json = ["dep:serde_json"]
-bincode = ["dep:bincode"]
-yaml = ["dep:serde_yaml"]
-cbor = ["dep:serde_cbor"]
+nano = ["dep:nanoserde"]
+serde = ["dep:serde"]
+json = ["dep:serde_json", "serde"]
+bincode = ["dep:bincode", "serde"]
+yaml = ["dep:serde_yaml", "serde"]
+cbor = ["dep:serde_cbor", "serde"]
 
 [[example]]
 name = "hello_world"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are currently two examples shipped with PickleDB:
 
 ### Version 0.4.0
 
-- Changed all doc tests from `ignore` to `no_run` so generated docs don't contain untested warnings
+- Changed all doc tests from `ignore` to `ignore` so generated docs don't contain untested warnings
 - Changed both instances of `lextend` to take iterators of references rather than a slice of values
 - Fixed bug in `load_test()`
 - Fixed rustfmt and clippy warnings

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,18 +3,32 @@
 //! * Loading an existing DB from a file
 //! * Setting and getting key-value pairs of different types
 
+#[cfg(feature = "nano")]
+use nanoserde::{DeBin, SerBin};
+#[cfg(any(feature = "json", feature = "bincode", feature = "nano"))]
 use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
+#[cfg(any(feature = "json", feature = "bincode"))]
 use serde::{Deserialize, Serialize};
+#[cfg(any(feature = "json", feature = "bincode", feature = "nano"))]
 use std::fmt::{self, Display, Formatter};
 
 /// Define an example struct which represents a rectangle.
-/// Next we'll show how to write and read it into the DB.
+/// Next we'll show how to use it in lists.
+#[cfg(any(feature = "json", feature = "bincode"))]
 #[derive(Serialize, Deserialize)]
 struct Rectangle {
     width: i32,
     length: i32,
 }
 
+#[cfg(feature = "nano")]
+#[derive(SerBin, DeBin)]
+struct Rectangle {
+    width: i32,
+    length: i32,
+}
+
+#[cfg(any(feature = "json", feature = "bincode", feature = "nano"))]
 impl Display for Rectangle {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Rectangle: length={}, width={}", self.length, self.width)
@@ -22,116 +36,138 @@ impl Display for Rectangle {
 }
 
 fn main() {
-    // create a new DB with AutoDum, meaning every change is written to the file,
-    // and with Json serialization
-    let mut db = PickleDb::new(
-        "example.db",
-        PickleDbDumpPolicy::AutoDump,
-        SerializationMethod::Json,
-    );
+    #[cfg(any(feature = "json", feature = "bincode", feature = "nano"))]
+    {
+        // create a new DB with AutoDum, meaning every change is written to the file,
+        // and with Json serialization
+        #[cfg(feature = "json")]
+        let mut db = PickleDb::new(
+            "example.db",
+            PickleDbDumpPolicy::AutoDump,
+            SerializationMethod::Json,
+        );
 
-    // set the value 100 to the key 'key1'
-    db.set("key1", &100).unwrap();
+        #[cfg(all(not(feature = "json"), any(feature = "nano", feature = "bincode")))]
+        let mut db = PickleDb::new(
+            "example.db",
+            PickleDbDumpPolicy::AutoDump,
+            SerializationMethod::Bin,
+        );
 
-    // set the value 1.1 to the key 'key2'
-    db.set("key2", &1.1).unwrap();
+        {
+            // set the value 100 to the key 'key1'
+            db.set("key1", &100_i32).unwrap();
 
-    // set the value 'hello world' to the key 'key3'
-    db.set("key3", &String::from("hello world")).unwrap();
+            // set the value 1.1 to the key 'key2'
+            db.set("key2", &1.1_f64).unwrap();
 
-    // set a vector value to the key 'key4'
-    db.set("key4", &vec![1, 2, 3]).unwrap();
+            // set the value 'hello world' to the key 'key3'
+            db.set("key3", &String::from("hello world")).unwrap();
 
-    // set a Rectangle value to the key 'key5'
-    db.set(
-        "key5",
-        &Rectangle {
-            width: 4,
-            length: 10,
-        },
-    )
-    .unwrap();
+            // set a vector value to the key 'key4'
+            db.set("key4", &vec![1_i32, 2_i32, 3_i32]).unwrap();
 
-    // print the value of key1
-    println!("The value of key1 is: {}", db.get::<i32>("key1").unwrap());
+            // set a Rectangle value to the key 'key5'
+            db.set(
+                "key5",
+                &Rectangle {
+                    width: 4,
+                    length: 10,
+                },
+            )
+            .unwrap();
 
-    // print the value of key2
-    println!("The value of key2 is: {}", db.get::<f32>("key2").unwrap());
+            // print the value of key1
+            println!("The value of key1 is: {}", db.get::<i32>("key1").unwrap());
 
-    // print the value of key3
-    println!(
-        "The value of key3 is: {}",
-        db.get::<String>("key3").unwrap()
-    );
+            // print the value of key2
+            println!("The value of key2 is: {}", db.get::<f32>("key2").unwrap());
 
-    // print the value of key4
-    println!(
-        "The value of key4 is: {:?}",
-        db.get::<Vec<i32>>("key4").unwrap()
-    );
+            // print the value of key3
+            println!(
+                "The value of key3 is: {}",
+                db.get::<String>("key3").unwrap()
+            );
 
-    // print the value of key5
-    println!(
-        "The value of key5 is: {}",
-        db.get::<Rectangle>("key5").unwrap()
-    );
+            // print the value of key4
+            println!(
+                "The value of key4 is: {:?}",
+                db.get::<Vec<i32>>("key4").unwrap()
+            );
 
-    // override the value of key1. Please note the new value is of a different type the former one
-    db.set("key1", &String::from("override")).unwrap();
+            // print the value of key5
+            println!(
+                "The value of key5 is: {}",
+                db.get::<Rectangle>("key5").unwrap()
+            );
 
-    // print the value of key1
-    println!(
-        "The value of key1 is: {}",
-        db.get::<String>("key1").unwrap()
-    );
+            // override the value of key1. Please note the new value is of a different type the former one
+            db.set("key1", &String::from("override")).unwrap();
 
-    // remove key2
-    db.rem("key2").unwrap();
+            // print the value of key1
+            println!(
+                "The value of key1 is: {}",
+                db.get::<String>("key1").unwrap()
+            );
 
-    // was key2 removed?
-    println!(
-        "key2 was removed. Is it still in the db? {}",
-        db.get::<f32>("key2").is_some()
-    );
+            // remove key2
+            db.rem("key2").unwrap();
 
-    // load an existing DB from a file (the same file in this case)
-    let db2 = PickleDb::load(
-        "example.db",
-        PickleDbDumpPolicy::DumpUponRequest,
-        SerializationMethod::Json,
-    )
-    .unwrap();
+            // was key2 removed?
+            println!(
+                "key2 was removed. Is it still in the db? {}",
+                db.get::<f32>("key2").is_some()
+            );
 
-    // print the value of key1
-    println!(
-        "Value of key1 as loaded from file is: {}",
-        db2.get::<String>("key1").unwrap()
-    );
+            // load an existing DB from a file (the same file in this case)
+            #[cfg(feature = "json")]
+            let db2 = PickleDb::load(
+                "example.db",
+                PickleDbDumpPolicy::DumpUponRequest,
+                SerializationMethod::Json,
+            )
+            .unwrap();
 
-    // iterate over all keys and values in the db
-    for kv in db.iter() {
-        match kv.get_key() {
-            "key1" => println!(
-                "Value of {} is: {}",
-                kv.get_key(),
-                kv.get_value::<String>().unwrap()
-            ),
-            "key3" => println!(
-                "Value of {} is: {}",
-                kv.get_key(),
-                kv.get_value::<String>().unwrap()
-            ),
-            "key4" => println!(
-                "Value of {} is: {:?}",
-                kv.get_key(),
-                kv.get_value::<Vec<i32>>().unwrap()
-            ),
-            "key5" => println!(
-                "Value of {} is: {}",
-                kv.get_key(),
-                kv.get_value::<Rectangle>().unwrap()
-            ),
-            _ => (),
+            #[cfg(all(not(feature = "json"), any(feature = "nano", feature = "bincode")))]
+            let db2 = PickleDb::load(
+                "example.db",
+                PickleDbDumpPolicy::DumpUponRequest,
+                SerializationMethod::Bin,
+            )
+            .unwrap();
+
+            // print the value of key1
+            println!(
+                "Value of key1 as loaded from file is: {}",
+                db2.get::<String>("key1").unwrap()
+            );
+
+            // iterate over all keys and values in the db
+            for kv in db.iter() {
+                match kv.get_key() {
+                    "key1" => println!(
+                        "Value of {} is: {}",
+                        kv.get_key(),
+                        kv.get_value::<String>().unwrap()
+                    ),
+                    "key3" => println!(
+                        "Value of {} is: {}",
+                        kv.get_key(),
+                        kv.get_value::<String>().unwrap()
+                    ),
+                    "key4" => println!(
+                        "Value of {} is: {:?}",
+                        kv.get_key(),
+                        kv.get_value::<Vec<i32>>().unwrap()
+                    ),
+                    "key5" => println!(
+                        "Value of {} is: {}",
+                        kv.get_key(),
+                        kv.get_value::<Rectangle>().unwrap()
+                    ),
+                    _ => (),
+                }
+            }
         }
     }
 }

--- a/examples/lists/src/main.rs
+++ b/examples/lists/src/main.rs
@@ -5,18 +5,32 @@
 //! * Adding and removing items of different type to lists
 //! * Retrieving list items
 
+#[cfg(feature = "nano")]
+use nanoserde::{DeBin, SerBin};
+#[cfg(any(feature = "bincode", feature = "nano"))]
 use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
+#[cfg(feature = "bincode")]
 use serde::{Deserialize, Serialize};
+#[cfg(any(feature = "bincode", feature = "nano"))]
 use std::fmt::{self, Display, Formatter};
 
 /// Define an example struct which represents a rectangle.
 /// Next we'll show how to use it in lists.
+#[cfg(feature = "bincode")]
 #[derive(Serialize, Deserialize)]
 struct Rectangle {
     width: i32,
     length: i32,
 }
 
+#[cfg(feature = "nano")]
+#[derive(SerBin, DeBin)]
+struct Rectangle {
+    width: i32,
+    length: i32,
+}
+
+#[cfg(any(feature = "bincode", feature = "nano"))]
 impl Display for Rectangle {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Rectangle: length={}, width={}", self.length, self.width)
@@ -24,6 +38,7 @@ impl Display for Rectangle {
 }
 
 /// Create a new DB and add one key-value pair to it
+#[cfg(any(feature = "bincode", feature = "nano"))]
 fn create_db(db_name: &str) {
     let mut new_db = PickleDb::new(
         db_name,
@@ -35,79 +50,79 @@ fn create_db(db_name: &str) {
 }
 
 fn main() {
-    // create a new DB
-    create_db("example.db");
+    #[cfg(any(feature = "bincode", feature = "nano"))]
+    {
+        // create a new DB
+        create_db("example.db");
 
-    // load the DB
-    let mut db = PickleDb::load(
-        "example.db",
-        PickleDbDumpPolicy::AutoDump,
-        SerializationMethod::Bin,
-    )
-    .unwrap();
+        // load the DB
+        let mut db = PickleDb::load(
+            "example.db",
+            PickleDbDumpPolicy::AutoDump,
+            SerializationMethod::Bin,
+        )
+        .unwrap();
 
-    // print the existing value in key1
-    println!("The value of key1 is: {}", db.get::<i32>("key1").unwrap());
+        // print the existing value in key1
+        println!("The value of key1 is: {}", db.get::<i32>("key1").unwrap());
 
-    // create a new list
-    db.lcreate("list1")
-        .unwrap()
-        // add an integer item to the list
-        .ladd(&200)
-        // add an floating point item to the list
-        .ladd(&2.1)
-        // add a string to the list
-        .ladd(&String::from("my list"))
-        // add a vector of chars to the list
-        .ladd(&vec!['a', 'b', 'c'])
-        // add multiple values to the list: add 3 rectangles
-        .lextend(&[
-            Rectangle {
-                width: 2,
-                length: 4,
-            },
-            Rectangle {
-                width: 10,
-                length: 22,
-            },
-            Rectangle {
-                width: 1,
-                length: 22,
-            },
-        ]);
+        // create a new list
+        db.lcreate("list1")
+            .unwrap()
+            // add an integer item to the list
+            .ladd(&200_i32)
+            // add an floating point item to the list
+            .ladd(&2.1_f64)
+            // add a string to the list
+            .ladd(&String::from("my list"))
+            // add multiple values to the list: add 3 rectangles
+            .lextend(&[
+                Rectangle {
+                    width: 2,
+                    length: 4,
+                },
+                Rectangle {
+                    width: 10,
+                    length: 22,
+                },
+                Rectangle {
+                    width: 1,
+                    length: 22,
+                },
+            ]);
 
-    // print the list length
-    println!("list1 length is: {}", db.llen("list1"));
+        // print the list length
+        println!("list1 length is: {}", db.llen("list1"));
 
-    // print the item in each position of the list
-    println!("list1[0] = {}", db.lget::<i32>("list1", 0).unwrap());
-    println!("list1[1] = {}", db.lget::<f64>("list1", 1).unwrap());
-    println!("list1[2] = {}", db.lget::<String>("list1", 2).unwrap());
-    println!("list1[3] = {:?}", db.lget::<Vec<char>>("list1", 3).unwrap());
-    println!("list1[4] = {}", db.lget::<Rectangle>("list1", 4).unwrap());
-    println!("list1[6] = {}", db.lget::<Rectangle>("list1", 5).unwrap());
-    println!("list1[7] = {}", db.lget::<Rectangle>("list1", 6).unwrap());
+        // print the item in each position of the list
+        println!("list1[0] = {}", db.lget::<i32>("list1", 0).unwrap());
+        println!("list1[1] = {}", db.lget::<f64>("list1", 1).unwrap());
+        println!("list1[2] = {}", db.lget::<String>("list1", 2).unwrap());
+        println!("list1[4] = {}", db.lget::<Rectangle>("list1", 4).unwrap());
+        println!("list1[6] = {}", db.lget::<Rectangle>("list1", 5).unwrap());
+        println!("list1[7] = {}", db.lget::<Rectangle>("list1", 6).unwrap());
 
-    // remove an item in the list
-    db.lpop::<i32>("list1", 0);
+        // remove an item in the list
+        db.lpop::<i32>("list1", 0);
 
-    // print the new first item of the list
-    println!("The new list1[0] = {}", db.lget::<f64>("list1", 0).unwrap());
+        // print the new first item of the list
+        println!("The new list1[0] = {}", db.lget::<f64>("list1", 0).unwrap());
 
-    // remove the entire list
-    db.lrem_list("list1").unwrap();
+        // remove the entire list
+        db.lrem_list("list1").unwrap();
 
-    // was list1 removed?
-    println!(
-        "list1 was removed. Is it still in the db? {}",
-        db.lexists("list1")
-    );
+        // was list1 removed?
+        println!(
+            "list1 was removed. Is it still in the db? {}",
+            db.lexists("list1")
+        );
 
-    // create a new list
-    db.lcreate("list2").unwrap().lextend(&[1, 2, 3, 4]);
+        // create a new list
+        db.lcreate("list2").unwrap().lextend(&[1, 2, 3, 4]);
 
-    // iterate over the items in list2
-    for item_iter in db.liter("list2") {
-        println!("Current item is: {}", item_iter.get_item::<i32>().unwrap());
+        // iterate over the items in list2
+        for item_iter in db.liter("list2") {
+            println!("Current item is: {}", item_iter.get_item::<i32>().unwrap());
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,8 @@ impl fmt::Debug for Error {
 impl std::error::Error for Error {}
 
 pub(crate) enum ErrorCode {
+    #[allow(dead_code)]
     Io(io::Error),
+    #[allow(dead_code)]
     Serialization(String),
 }

--- a/src/extenders.rs
+++ b/src/extenders.rs
@@ -1,4 +1,7 @@
 use crate::pickledb::PickleDb;
+#[cfg(feature = "nano")]
+use nanoserde::SerBin;
+#[cfg(not(feature = "nano"))]
 use serde::Serialize;
 
 /// A struct for extending PickleDB lists and adding more items to them
@@ -23,7 +26,7 @@ impl<'a> PickleDbListExtender<'a> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// # let mut db = pickledb::PickleDb::new_bin("1.db", pickledb::PickleDbDumpPolicy::AutoDump);
     /// // create a new list
     /// db.lcreate("list1").unwrap()
@@ -34,9 +37,18 @@ impl<'a> PickleDbListExtender<'a> {
     ///   .ladd(&vec!["aa", "bb", "cc"]);
     /// ```
     ///
+    #[cfg(not(feature = "nano"))]
     pub fn ladd<V>(&mut self, value: &V) -> PickleDbListExtender
     where
         V: Serialize,
+    {
+        self.db.ladd(&self.list_name, value).unwrap()
+    }
+
+    #[cfg(feature = "nano")]
+    pub fn ladd<V>(&mut self, value: &V) -> PickleDbListExtender
+    where
+        V: SerBin,
     {
         self.db.ladd(&self.list_name, value).unwrap()
     }
@@ -59,7 +71,7 @@ impl<'a> PickleDbListExtender<'a> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// # let mut db = pickledb::PickleDb::new_bin("1.db", pickledb::PickleDbDumpPolicy::AutoDump);
     /// // create a new list
     /// db.lcreate("list1");
@@ -73,9 +85,19 @@ impl<'a> PickleDbListExtender<'a> {
     /// // now the list contains 6 items and looks like this: [100, 200, 300, "aa, "bb", "cc"]
     /// ```
     ///
+    #[cfg(not(feature = "nano"))]
     pub fn lextend<'i, V, I>(&mut self, seq: I) -> PickleDbListExtender
     where
         V: 'i + Serialize,
+        I: IntoIterator<Item = &'i V>,
+    {
+        self.db.lextend(&self.list_name, seq).unwrap()
+    }
+
+    #[cfg(feature = "nano")]
+    pub fn lextend<'i, V, I>(&mut self, seq: I) -> PickleDbListExtender
+    where
+        V: 'i + SerBin,
         I: IntoIterator<Item = &'i V>,
     {
         self.db.lextend(&self.list_name, seq).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,10 @@
 //! Apart from this dump policy, persistency is also kept by a implementing the `Drop` trait for the `PickleDB` object which ensures all in-memory data
 //! is dumped to the file upon destruction of the object.
 //!
+
+#[cfg(all(feature = "serde", feature = "nano"))]
+compile_error!("Either serde (json, yaml, cbor, bincode features) or nanoserde (nano feature) may be used, but not both");
+
 pub use self::extenders::PickleDbListExtender;
 pub use self::iterators::{
     PickleDbIterator, PickleDbIteratorItem, PickleDbListIterator, PickleDbListIteratorItem,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,6 +6,7 @@ pub struct TestResources {
 }
 
 impl TestResources {
+    #[allow(dead_code)]
     pub fn new(file: &str) -> TestResources {
         TestResources {
             file: String::from(file),

--- a/tests/pickledb_advanced_tests.rs
+++ b/tests/pickledb_advanced_tests.rs
@@ -1,16 +1,15 @@
-use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
-use rand::distributions::Alphanumeric;
-use rand::seq::SliceRandom;
-use rand::{thread_rng, Rng};
-use std::collections::HashMap;
-use std::iter;
+mod import {
+    pub use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
+    pub use rand::distributions::Alphanumeric;
+    pub use rand::seq::SliceRandom;
+    pub use rand::{thread_rng, Rng};
+    pub use rstest::rstest_parametrize;
+    pub use std::collections::HashMap;
+    pub use std::iter;
+}
+use import::*;
 
 mod common;
-
-#[cfg(test)]
-extern crate rstest;
-
-use rstest::rstest_parametrize;
 
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn lists_and_values(ser_method_int: i32) {
@@ -24,15 +23,15 @@ fn lists_and_values(ser_method_int: i32) {
 
     // set a few values
     assert!(db.set("key1", &String::from("val1")).is_ok());
-    assert!(db.set("key2", &1).is_ok());
+    assert!(db.set("key2", &1_i32).is_ok());
     assert!(db.set("key3", &vec![1, 2, 3]).is_ok());
 
     // create a few lists and add values to them
-    db.lcreate("list1").unwrap().lextend(&[1, 2, 3]);
+    db.lcreate("list1").unwrap().lextend(&[1_i32, 2_i32, 3_i32]);
 
     db.lcreate("list2")
         .unwrap()
-        .ladd(&1.1)
+        .ladd(&1.1_f64)
         .ladd(&String::from("some val"));
 
     // read keys and lists

--- a/tests/pickledb_dump_policy_tests.rs
+++ b/tests/pickledb_dump_policy_tests.rs
@@ -1,14 +1,30 @@
-use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
-use std::time::Duration;
-use std::{thread, time};
+mod imports {
+    pub use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
+    pub use rstest::rstest_parametrize;
+    pub use std::time::Duration;
+    pub use std::{thread, time};
+}
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
+use imports::*;
 
 mod common;
 
 #[cfg(test)]
 extern crate rstest;
 
-use rstest::rstest_parametrize;
-
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn auto_dump_policy_test(ser_method_int: i32) {
     test_setup!("auto_dump_policy_test", ser_method_int, db_name);
@@ -85,6 +101,13 @@ fn auto_dump_policy_test(ser_method_int: i32) {
     }
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn read_only_policy_test(ser_method_int: i32) {
     test_setup!("read_only_policy_test", ser_method_int, db_name);
@@ -132,6 +155,13 @@ fn read_only_policy_test(ser_method_int: i32) {
     }
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn dump_upon_request_policy_test(ser_method_int: i32) {
     test_setup!("dump_upon_request_policy_test", ser_method_int, db_name);
@@ -170,6 +200,13 @@ fn dump_upon_request_policy_test(ser_method_int: i32) {
     }
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn periodic_dump_policy_test(ser_method_int: i32) {
     test_setup!("periodic_dump_policy_test", ser_method_int, db_name);

--- a/tests/pickledb_error_tests.rs
+++ b/tests/pickledb_error_tests.rs
@@ -1,16 +1,35 @@
-use pickledb::error::ErrorType;
-use pickledb::{PickleDb, PickleDbDumpPolicy};
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "yaml",
+    feature = "nano"
+))]
+mod imports {
+    pub use fs2::FileExt;
+    pub use pickledb::error::ErrorType;
+    pub use pickledb::{PickleDb, PickleDbDumpPolicy};
+    pub use std::fs::File;
+}
 
-#[macro_use(matches)]
-extern crate matches;
-extern crate fs2;
-
-use fs2::FileExt;
-use std::fs::File;
+#[allow(unused_imports)]
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "yaml",
+    feature = "nano"
+))]
+use imports::*;
 
 mod common;
 
 #[test]
+#[cfg(all(
+    feature = "serde",
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml"
+))]
 fn load_serialization_error_test() {
     set_test_rsc!("json_db.db");
 
@@ -49,6 +68,7 @@ fn load_serialization_error_test() {
 }
 
 #[test]
+#[cfg(any(feature = "bincode", feature = "nano"))]
 fn load_error_test() {
     // load a file that doesn't exist and make sure we get an IO error
     let load_result = PickleDb::load_bin("doesnt_exists.db", PickleDbDumpPolicy::NeverDump);
@@ -58,6 +78,7 @@ fn load_error_test() {
 }
 
 #[allow(clippy::cognitive_complexity)]
+#[cfg(feature = "json")]
 #[test]
 fn dump_error_test() {
     set_test_rsc!("dump_error_test.db");

--- a/tests/pickledb_key_value_tests.rs
+++ b/tests/pickledb_key_value_tests.rs
@@ -1,15 +1,56 @@
 #![allow(clippy::float_cmp)]
 
-use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
+mod import {
+    pub use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
+    pub use rstest::rstest_parametrize;
+}
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
+use import::*;
+
+#[cfg(feature = "nano")]
+use nanoserde::{DeBin, SerBin};
+#[cfg(not(feature = "nano"))]
 use serde::{Deserialize, Serialize};
+
+#[cfg(not(feature = "nano"))]
+#[derive(Serialize, Deserialize, Debug)]
+struct Coor {
+    x: i32,
+    y: i32,
+}
+
+#[cfg(feature = "nano")]
+#[derive(SerBin, DeBin, Debug)]
+struct Coor {
+    x: i32,
+    y: i32,
+}
 
 mod common;
 
 #[cfg(test)]
 extern crate rstest;
 
-use rstest::rstest_parametrize;
-
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn basic_set_get(ser_method_int: i32) {
     test_setup!("basic_set_get", ser_method_int, db_name);
@@ -36,12 +77,6 @@ fn basic_set_get(ser_method_int: i32) {
     let myvec = vec![1, 2, 3];
     db.set("vec", &myvec).unwrap();
 
-    // set a struct
-    #[derive(Serialize, Deserialize, Debug)]
-    struct Coor {
-        x: i32,
-        y: i32,
-    }
     let mycoor = Coor { x: 1, y: 2 };
     db.set("struct", &mycoor).unwrap();
 
@@ -58,6 +93,13 @@ fn basic_set_get(ser_method_int: i32) {
     assert_eq!(db.get::<Coor>("struct").unwrap().y, mycoor.y);
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn set_load_get(ser_method_int: i32) {
     test_setup!("set_load_get", ser_method_int, db_name);
@@ -85,12 +127,6 @@ fn set_load_get(ser_method_int: i32) {
     let myvec = vec![1, 2, 3];
     db.set("vec", &myvec).unwrap();
 
-    // set a struct
-    #[derive(Serialize, Deserialize, Debug)]
-    struct Coor {
-        x: i32,
-        y: i32,
-    }
     let mycoor = Coor { x: 1, y: 2 };
     db.set("struct", &mycoor).unwrap();
 
@@ -113,6 +149,13 @@ fn set_load_get(ser_method_int: i32) {
     assert_eq!(read_db.get::<Coor>("struct").unwrap().y, mycoor.y);
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn set_load_get_auto_dump(ser_method_int: i32) {
     test_setup!("set_load_get_auto_dump", ser_method_int, db_name);
@@ -140,12 +183,6 @@ fn set_load_get_auto_dump(ser_method_int: i32) {
     let myvec = vec![1, 2, 3];
     db.set("vec", &myvec).unwrap();
 
-    // set a struct
-    #[derive(Serialize, Deserialize, Debug)]
-    struct Coor {
-        x: i32,
-        y: i32,
-    }
     let mycoor = Coor { x: 1, y: 2 };
     db.set("struct", &mycoor).unwrap();
 
@@ -164,6 +201,7 @@ fn set_load_get_auto_dump(ser_method_int: i32) {
     assert_eq!(read_db.get::<Coor>("struct").unwrap().y, mycoor.y);
 }
 
+#[cfg(any(feature = "bincode", feature = "nano"))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn set_load_get_auto_dump2(ser_method_int: i32) {
     test_setup!("set_load_get_auto_dump2", ser_method_int, db_name);
@@ -209,6 +247,7 @@ fn set_load_get_auto_dump2(ser_method_int: i32) {
     db.set("num", &vec![1, 2, 3]).unwrap();
 
     // read the new value
+    #[allow(irrefutable_let_patterns)]
     if let SerializationMethod::Bin = ser_method!(ser_method_int) {
         // N/A
     } else {
@@ -221,6 +260,13 @@ fn set_load_get_auto_dump2(ser_method_int: i32) {
     }
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn set_special_strings(ser_method_int: i32) {
     test_setup!("set_special_strings", ser_method_int, db_name);
@@ -268,6 +314,7 @@ fn set_special_strings(ser_method_int: i32) {
     );
 }
 
+#[cfg(feature = "yaml")]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn edge_cases(ser_method_int: i32) {
     test_setup!("edge_cases", ser_method_int, db_name);
@@ -287,6 +334,7 @@ fn edge_cases(ser_method_int: i32) {
 
     assert_eq!(db.get::<i32>("num"), Some(x));
     assert_eq!(read_db.get::<i32>("num"), Some(x));
+    #[allow(irrefutable_let_patterns)]
     if let SerializationMethod::Yaml = ser_method!(ser_method_int) {
         // N/A
     } else {
@@ -295,6 +343,13 @@ fn edge_cases(ser_method_int: i32) {
     }
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn get_all_keys(ser_method_int: i32) {
     test_setup!("get_all_keys", ser_method_int, db_name);
@@ -327,6 +382,13 @@ fn get_all_keys(ser_method_int: i32) {
     }
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn rem_keys(ser_method_int: i32) {
     test_setup!("rem_keys", ser_method_int, db_name);
@@ -366,6 +428,13 @@ fn rem_keys(ser_method_int: i32) {
     assert_eq!(read_db.total_keys(), 8);
 }
 
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "cbor",
+    feature = "yaml",
+    feature = "nano"
+))]
 #[rstest_parametrize(ser_method_int, case(0), case(1), case(2), case(3))]
 fn iter_test(ser_method_int: i32) {
     test_setup!("iter_test", ser_method_int, db_name);
@@ -379,10 +448,11 @@ fn iter_test(ser_method_int: i32) {
 
     let keys = vec!["key1", "key2", "key3", "key4", "key5"];
     // add a few keys and values
-    db.set(keys[0], &1).unwrap();
-    db.set(keys[1], &1.1).unwrap();
+    db.set(keys[0], &1_i64).unwrap();
+    db.set(keys[1], &1.1_f64).unwrap();
     db.set(keys[2], &String::from("value1")).unwrap();
-    db.set(keys[3], &vec![1, 2, 3]).unwrap();
+    db.set(keys[3], &vec![1_i32, 2_i32, 3_i32]).unwrap();
+    #[cfg(not(feature = "nano"))]
     db.set(keys[4], &('a', 'b', 'c')).unwrap();
 
     // iterate the db
@@ -403,6 +473,8 @@ fn iter_test(ser_method_int: i32) {
                 String::from("value1")
             ),
             "key4" => assert_eq!(key_value.get_value::<Vec<i32>>().unwrap(), vec![1, 2, 3]),
+
+            #[cfg(not(feature = "nano"))]
             "key5" => assert_eq!(
                 key_value.get_value::<(char, char, char)>().unwrap(),
                 ('a', 'b', 'c')
@@ -412,5 +484,8 @@ fn iter_test(ser_method_int: i32) {
     }
 
     // verify all 5 keys were seen
+    #[cfg(not(feature = "nano"))]
     assert_eq!(keys_seen.iter().filter(|&t| *t).count(), 5);
+    #[cfg(feature = "nano")]
+    assert_eq!(keys_seen.iter().filter(|&t| *t).count(), 4);
 }


### PR DESCRIPTION
Wanted to use pickleDB, but trying to avoid having quote + syn in my build tree. This change optionally reduces the number of deps for the library to one, with similar performance to bincode according to the test suite. 